### PR TITLE
Fix particle namelist startup write and default sampling to true

### DIFF
--- a/src/core_ocean/analysis_members/Registry_lagrangian_particle_tracking.xml
+++ b/src/core_ocean/analysis_members/Registry_lagrangian_particle_tracking.xml
@@ -55,11 +55,11 @@
 			description="Specify whether particles should be reset when they enter the resetInsideRegionMaskValue1 mask."
 			possible_values=".false. or .true."
 		/>
-		<nml_option name="config_AM_lagrPartTrack_sample_temperature" type="logical" default_value=".false." units="unitless"
+		<nml_option name="config_AM_lagrPartTrack_sample_temperature" type="logical" default_value=".true." units="unitless"
 			description="If true, particles sample temperature."
 			possible_values=".true. or .false."
 		/>
-		<nml_option name="config_AM_lagrPartTrack_sample_salinity" type="logical" default_value=".false." units="unitless"
+		<nml_option name="config_AM_lagrPartTrack_sample_salinity" type="logical" default_value=".true." units="unitless"
 			description="If true, particles sample salinity."
 			possible_values=".true. or .false."
 		/>

--- a/testing_and_setup/compass/utility_scripts/LIGHTparticles/user_nl_mpaso
+++ b/testing_and_setup/compass/utility_scripts/LIGHTparticles/user_nl_mpaso
@@ -28,5 +28,5 @@ config_write_output_on_startup = .true.
  config_am_lagrparttrack_reset_global_timestamp = '0029_23:59:59'
  config_am_lagrparttrack_reset_if_inside_region = .false.
  config_am_lagrparttrack_reset_if_outside_region = .false.
- config_am_lagrparttrack_write_on_startup = .true.
+ config_am_lagrparttrack_write_on_startup = .false.
 /


### PR DESCRIPTION
Simple edits based on our conversations over the past few days

* Namelist now does not write particle output on startup

* Temperature and salinity sampling default to true in registry until
the E3SM registry is updated.


