### PR TITLE
add horizontal interpolation for all passive tracers

### DIFF
--- a/src/core_ocean/analysis_members/Registry_lagrangian_particle_tracking.xml
+++ b/src/core_ocean/analysis_members/Registry_lagrangian_particle_tracking.xml
@@ -74,6 +74,30 @@
 		<nml_option name="config_AM_lagrPartTrack_sample_ALK" type="logical" default_value=".false." units="unitless"
 			description="If true, particles sample ALK."
 			possible_values=".true. or .false."
+         />
+		<nml_option name="config_AM_lagrPartTrack_sample_PO4" type="logical" default_value=".false." units="unitless"
+			description="If true, particles sample PO4."
+			possible_values=".true. or .false."
+        />
+		<nml_option name="config_AM_lagrPartTrack_sample_NO3" type="logical" default_value=".false." units="unitless"
+			description="If true, particles sample NO3."
+			possible_values=".true. or .false."
+        />
+		<nml_option name="config_AM_lagrPartTrack_sample_SiO3" type="logical" default_value=".false." units="unitless"
+			description="If true, particles sample SiO3."
+			possible_values=".true. or .false."
+        />
+		<nml_option name="config_AM_lagrPartTrack_sample_NH4" type="logical" default_value=".false." units="unitless"
+			description="If true, particles sample NH4."
+			possible_values=".true. or .false."
+        />
+		<nml_option name="config_AM_lagrPartTrack_sample_Fe" type="logical" default_value=".false." units="unitless"
+			description="If true, particles sample Fe."
+			possible_values=".true. or .false."
+        />
+		<nml_option name="config_AM_lagrPartTrack_sample_O2" type="logical" default_value=".false." units="unitless"
+			description="If true, particles sample O2."
+			possible_values=".true. or .false."
         />
 	</nml_record>
 
@@ -351,6 +375,24 @@
 		/>
         <var name="particleALK" type="real" dimensions="nParticles Time" units="meq m^{-3}"
 			 description="sampled alkalinity for particle"
+        />
+        <var name="particlePO4" type="real" dimensions="nParticles Time" units="mmol m^{-3}"
+			 description="sampled dissolved inorganic phosphate for particle"
+		/>
+        <var name="particleNO3" type="real" dimensions="nParticles Time" units="meq m^{-3}"
+			 description="sampled dissolved inorganic nitrate for particle"
+		/>
+        <var name="particleSiO3" type="real" dimensions="nParticles Time" units="mmol m^{-3}"
+			 description="sampled dissolved inorganic silicate for particle"
+		/>
+        <var name="particleNH4" type="real" dimensions="nParticles Time" units="meq m^{-3}"
+			 description="sampled dissolved inorganic ammonia for particle"
+		/>
+        <var name="particleFe" type="real" dimensions="nParticles Time" units="mmol m^{-3}"
+			 description="sampled dissolved inorganic iron for particle"
+		/>
+        <var name="particleO2" type="real" dimensions="nParticles Time" units="meq m^{-3}"
+			 description="sampled dissolved oxygen for particle"
 		/>
 	</var_struct>
 <!--

--- a/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
@@ -343,7 +343,7 @@ contains
       real (kind=RKIND), pointer :: particleALK
 
       ! PO4
-      logical, pointer :: config_AM_lagrPartTrack_sample_PO$
+      logical, pointer :: config_AM_lagrPartTrack_sample_PO4
       real (kind=RKIND), pointer :: particlePO4
       
       ! NO3

--- a/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
@@ -325,7 +325,13 @@ contains
       ! BGC tracers
       logical, pointer :: config_use_ecosysTracers
       integer, pointer :: index_DIC, &
-                          index_ALK
+                          index_ALK, &
+                          index_PO4, &
+                          index_NO3, &
+                          index_SiO3, &
+                          index_NH4, &
+                          index_Fe, &
+                          index_O2
       real (kind=RKIND), dimension(:,:,:), pointer :: ecosysTracers
 
       ! DIC
@@ -335,6 +341,30 @@ contains
       ! ALK
       logical, pointer :: config_AM_lagrPartTrack_sample_ALK
       real (kind=RKIND), pointer :: particleALK
+
+      ! PO4
+      logical, pointer :: config_AM_lagrPartTrack_sample_PO$
+      real (kind=RKIND), pointer :: particlePO4
+      
+      ! NO3
+      logical, pointer :: config_AM_lagrPartTrack_sample_NO3
+      real (kind=RKIND), pointer :: particleNO3
+
+      ! SiO3
+      logical, pointer :: config_AM_lagrPartTrack_sample_SiO3
+      real (kind=RKIND), pointer :: particleSiO3
+
+      ! NH4
+      logical, pointer :: config_AM_lagrPartTrack_sample_NH4
+      real (kind=RKIND), pointer :: particleNH4
+
+      ! Fe
+      logical, pointer :: config_AM_lagrPartTrack_sample_Fe
+      real (kind=RKIND), pointer :: particleFe
+
+      ! O2
+      logical, pointer :: config_AM_lagrPartTrack_sample_O2
+      real (kind=RKIND), pointer :: particleO2
 
       REAL (kind=RKIND), parameter :: eps=1e-12
 
@@ -363,6 +393,12 @@ contains
       call mpas_pool_get_config(ocnConfigs, 'config_use_ecosysTracers', config_use_ecosysTracers)
       call mpas_pool_get_config(ocnConfigs, 'config_AM_lagrPartTrack_sample_DIC', config_AM_lagrPartTrack_sample_DIC)
       call mpas_pool_get_config(ocnConfigs, 'config_AM_lagrPartTrack_sample_ALK', config_AM_lagrPartTrack_sample_ALK)
+      call mpas_pool_get_config(ocnConfigs, 'config_AM_lagrPartTrack_sample_PO4', config_AM_lagrPartTrack_sample_PO4)
+      call mpas_pool_get_config(ocnConfigs, 'config_AM_lagrPartTrack_sample_NO3', config_AM_lagrPartTrack_sample_NO3)
+      call mpas_pool_get_config(ocnConfigs, 'config_AM_lagrPartTrack_sample_SiO3', config_AM_lagrPartTrack_sample_SiO3)
+      call mpas_pool_get_config(ocnConfigs, 'config_AM_lagrPartTrack_sample_NH4', config_AM_lagrPartTrack_sample_NH4)
+      call mpas_pool_get_config(ocnConfigs, 'config_AM_lagrPartTrack_sample_Fe', config_AM_lagrPartTrack_sample_Fe)
+      call mpas_pool_get_config(ocnConfigs, 'config_AM_lagrPartTrack_sample_O2', config_AM_lagrPartTrack_sample_O2)
        
       if (trim(config_AM_lagrPartTrack_reset_criteria) == 'none') then
         config_AM_lagrPartTrack_reset_particles = .False.
@@ -428,6 +464,12 @@ contains
           call mpas_pool_get_array(tracersPool, 'ecosysTracers', ecosysTracers, timeLevel)
           call mpas_pool_get_dimension(tracersPool, 'index_DIC', index_DIC)
           call mpas_pool_get_dimension(tracersPool, 'index_ALK', index_ALK)
+          call mpas_pool_get_dimension(tracersPool, 'index_PO4', index_PO4)
+          call mpas_pool_get_dimension(tracersPool, 'index_NO3', index_NO3)
+          call mpas_pool_get_dimension(tracersPool, 'index_SiO3', index_SiO3)
+          call mpas_pool_get_dimension(tracersPool, 'index_NH4', index_NH4)
+          call mpas_pool_get_dimension(tracersPool, 'index_Fe', index_Fe)
+          call mpas_pool_get_dimension(tracersPool, 'index_O2', index_O2)
         end if
 
         call mpas_pool_get_array(meshPool, 'verticesOnCell', verticesOnCell)
@@ -541,6 +583,12 @@ contains
           if (config_use_ecosysTracers) then
             call mpas_pool_get_array(particle % haloDataPool, 'particleDIC', particleDIC)
             call mpas_pool_get_array(particle % haloDataPool, 'particleALK', particleALK)
+            call mpas_pool_get_array(particle % haloDataPool, 'particlePO4', particlePO4)
+            call mpas_pool_get_array(particle % haloDataPool, 'particleNO3', particleNO3)
+            call mpas_pool_get_array(particle % haloDataPool, 'particleSiO3', particleSiO3)
+            call mpas_pool_get_array(particle % haloDataPool, 'particleNH4', particleNH4)
+            call mpas_pool_get_array(particle % haloDataPool, 'particleFe', particleFe)
+            call mpas_pool_get_array(particle % haloDataPool, 'particleO2', particleO2)
           end if
 
 !          call mpas_pool_get_array(particle % haloDataPool, 'lonVel', lonVel)
@@ -870,6 +918,132 @@ contains
                      ecosysTracers(index_ALK,:,iCell), particleALK)
                  end if
                  call mpas_log_write('done testing output for ALK')
+               end if
+
+               if (config_AM_lagrPartTrack_sample_PO4) then
+                 call mpas_log_write('testing output for PO4')
+                 if (config_AM_lagrPartTrack_sample_horizontal_interp) then
+                   call interp_scalars(particlePO4, ecosysTracers(index_PO4,:,:), &
+                     verticesOnCell(:,iCell), nCellVerticesArray(iCell), &
+                     particlePosition(1),particlePosition(2),particlePosition(3), &
+                     xVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     yVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     zVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     xCell, yCell, zCell, &
+                     meshPool, &
+                     cellsOnVertex, &
+                     verticalTreatment, maxLevelCell, iCell, buoyancyParticle, buoyancyTimeInterp, &
+                     zMid, indexLevel)
+                 else
+                   call interp_cell_scalars(iLevel, maxLevelCell(iCell), -zLevelParticle, -zMid(:,iCell), &
+                     ecosysTracers(index_PO4,:,iCell), particlePO4)
+                 end if
+                 call mpas_log_write('done testing output for PO4')
+               end if
+             
+               if (config_AM_lagrPartTrack_sample_NO3) then
+                 call mpas_log_write('testing output for NO3')
+                 if (config_AM_lagrPartTrack_sample_horizontal_interp) then
+                   call interp_scalars(particleNO3, ecosysTracers(index_NO3,:,:), &
+                     verticesOnCell(:,iCell), nCellVerticesArray(iCell), &
+                     particlePosition(1),particlePosition(2),particlePosition(3), &
+                     xVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     yVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     zVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     xCell, yCell, zCell, &
+                     meshPool, &
+                     cellsOnVertex, &
+                     verticalTreatment, maxLevelCell, iCell, buoyancyParticle, buoyancyTimeInterp, &
+                     zMid, indexLevel)
+                 else
+                   call interp_cell_scalars(iLevel, maxLevelCell(iCell), -zLevelParticle, -zMid(:,iCell), &
+                     ecosysTracers(index_NO3,:,iCell), particleNO3)
+                 end if
+                 call mpas_log_write('done testing output for NO3')
+               end if
+
+               if (config_AM_lagrPartTrack_sample_SiO3) then
+                 call mpas_log_write('testing output for SiO3')
+                 if (config_AM_lagrPartTrack_sample_horizontal_interp) then
+                   call interp_scalars(particleSiO3, ecosysTracers(index_SiO3,:,:), &
+                     verticesOnCell(:,iCell), nCellVerticesArray(iCell), &
+                     particlePosition(1),particlePosition(2),particlePosition(3), &
+                     xVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     yVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     zVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     xCell, yCell, zCell, &
+                     meshPool, &
+                     cellsOnVertex, &
+                     verticalTreatment, maxLevelCell, iCell, buoyancyParticle, buoyancyTimeInterp, &
+                     zMid, indexLevel)
+                 else
+                   call interp_cell_scalars(iLevel, maxLevelCell(iCell), -zLevelParticle, -zMid(:,iCell), &
+                     ecosysTracers(index_SiO3,:,iCell), particleSiO3)
+                 end if
+                 call mpas_log_write('done testing output for SiO3')
+               end if
+
+               if (config_AM_lagrPartTrack_sample_NH4) then
+                 call mpas_log_write('testing output for NH4')
+                 if (config_AM_lagrPartTrack_sample_horizontal_interp) then
+                   call interp_scalars(particleNH4, ecosysTracers(index_NH4,:,:), &
+                     verticesOnCell(:,iCell), nCellVerticesArray(iCell), &
+                     particlePosition(1),particlePosition(2),particlePosition(3), &
+                     xVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     yVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     zVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     xCell, yCell, zCell, &
+                     meshPool, &
+                     cellsOnVertex, &
+                     verticalTreatment, maxLevelCell, iCell, buoyancyParticle, buoyancyTimeInterp, &
+                     zMid, indexLevel)
+                 else
+                   call interp_cell_scalars(iLevel, maxLevelCell(iCell), -zLevelParticle, -zMid(:,iCell), &
+                     ecosysTracers(index_NH4,:,iCell), particleNH4)
+                 end if
+                 call mpas_log_write('done testing output for NH4')
+               end if
+
+               if (config_AM_lagrPartTrack_sample_Fe) then
+                 call mpas_log_write('testing output for Fe')
+                 if (config_AM_lagrPartTrack_sample_horizontal_interp) then
+                   call interp_scalars(particleFe, ecosysTracers(index_Fe,:,:), &
+                     verticesOnCell(:,iCell), nCellVerticesArray(iCell), &
+                     particlePosition(1),particlePosition(2),particlePosition(3), &
+                     xVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     yVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     zVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     xCell, yCell, zCell, &
+                     meshPool, &
+                     cellsOnVertex, &
+                     verticalTreatment, maxLevelCell, iCell, buoyancyParticle, buoyancyTimeInterp, &
+                     zMid, indexLevel)
+                 else
+                   call interp_cell_scalars(iLevel, maxLevelCell(iCell), -zLevelParticle, -zMid(:,iCell), &
+                     ecosysTracers(index_Fe,:,iCell), particleFe)
+                 end if
+                 call mpas_log_write('done testing output for Fe')
+               end if
+
+               if (config_AM_lagrPartTrack_sample_O2) then
+                 call mpas_log_write('testing output for O2')
+                 if (config_AM_lagrPartTrack_sample_horizontal_interp) then
+                   call interp_scalars(particleO2, ecosysTracers(index_O2,:,:), &
+                     verticesOnCell(:,iCell), nCellVerticesArray(iCell), &
+                     particlePosition(1),particlePosition(2),particlePosition(3), &
+                     xVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     yVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     zVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     xCell, yCell, zCell, &
+                     meshPool, &
+                     cellsOnVertex, &
+                     verticalTreatment, maxLevelCell, iCell, buoyancyParticle, buoyancyTimeInterp, &
+                     zMid, indexLevel)
+                 else
+                   call interp_cell_scalars(iLevel, maxLevelCell(iCell), -zLevelParticle, -zMid(:,iCell), &
+                     ecosysTracers(index_O2,:,iCell), particleO2)
+                 end if
+                 call mpas_log_write('done testing output for O2')
                end if
              end if
            end if
@@ -1858,11 +2032,29 @@ contains
       real (kind=RKIND), dimension(:,:,:), pointer :: ecosysTracers
       logical, pointer :: config_use_ecosysTracers
       integer, pointer :: index_DIC, &
-                          index_ALK
+                          index_ALK, &
+                          index_PO4, &
+                          index_NO3, &
+                          index_SiO3, &
+                          index_NH4, &
+                          index_Fe, &
+                          index_O2
       logical, pointer :: config_AM_lagrPartTrack_sample_DIC
       real (kind=RKIND), pointer :: particleDIC
       logical, pointer :: config_AM_lagrPartTrack_sample_ALK
       real (kind=RKIND), pointer :: particleALK
+      logical, pointer :: config_AM_lagrPartTrack_sample_PO$
+      real (kind=RKIND), pointer :: particlePO4
+      logical, pointer :: config_AM_lagrPartTrack_sample_NO3
+      real (kind=RKIND), pointer :: particleNO3
+      logical, pointer :: config_AM_lagrPartTrack_sample_SiO3
+      real (kind=RKIND), pointer :: particleSiO3
+      logical, pointer :: config_AM_lagrPartTrack_sample_NH4
+      real (kind=RKIND), pointer :: particleNH4
+      logical, pointer :: config_AM_lagrPartTrack_sample_Fe
+      real (kind=RKIND), pointer :: particleFe
+      logical, pointer :: config_AM_lagrPartTrack_sample_O2
+      real (kind=RKIND), pointer :: particleO2
 
       err = 0
 
@@ -1873,6 +2065,12 @@ contains
       call mpas_pool_get_config(ocnConfigs, 'config_use_ecosysTracers', config_use_ecosysTracers)
       call mpas_pool_get_config(ocnConfigs, 'config_AM_lagrPartTrack_sample_DIC', config_AM_lagrPartTrack_sample_DIC)
       call mpas_pool_get_config(ocnConfigs, 'config_AM_lagrPartTrack_sample_ALK', config_AM_lagrPartTrack_sample_ALK)
+      call mpas_pool_get_config(ocnConfigs, 'config_AM_lagrPartTrack_sample_PO4', config_AM_lagrPartTrack_sample_PO4)
+      call mpas_pool_get_config(ocnConfigs, 'config_AM_lagrPartTrack_sample_NO3', config_AM_lagrPartTrack_sample_NO3)
+      call mpas_pool_get_config(ocnConfigs, 'config_AM_lagrPartTrack_sample_SiO3', config_AM_lagrPartTrack_sample_SiO3)
+      call mpas_pool_get_config(ocnConfigs, 'config_AM_lagrPartTrack_sample_NH4', config_AM_lagrPartTrack_sample_NH4)
+      call mpas_pool_get_config(ocnConfigs, 'config_AM_lagrPartTrack_sample_Fe', config_AM_lagrPartTrack_sample_Fe)
+      call mpas_pool_get_config(ocnConfigs, 'config_AM_lagrPartTrack_sample_O2', config_AM_lagrPartTrack_sample_O2)
 
       dminfo = domain % dminfo
 
@@ -1915,6 +2113,12 @@ contains
           call mpas_pool_get_array(tracersPool, 'ecosysTracers', ecosysTracers, timeLevel=timeLevel)
           call mpas_pool_get_dimension(tracersPool, 'index_DIC', index_DIC)
           call mpas_pool_get_dimension(tracersPool, 'index_ALK', index_ALK)
+          call mpas_pool_get_dimension(tracersPool, 'index_PO4', index_PO4)
+          call mpas_pool_get_dimension(tracersPool, 'index_NO3', index_NO3)
+          call mpas_pool_get_dimension(tracersPool, 'index_SiO3', index_SiO3)
+          call mpas_pool_get_dimension(tracersPool, 'index_NH4', index_NH4)
+          call mpas_pool_get_dimension(tracersPool, 'index_Fe', index_Fe)
+          call mpas_pool_get_dimension(tracersPool, 'index_O2', index_O2)
         end if 
 
         call mpas_pool_get_array(meshPool, 'verticesOnCell', verticesOnCell)
@@ -1968,6 +2172,12 @@ contains
           if (config_use_ecosysTracers) then
             call mpas_pool_get_array(particle % haloDataPool, 'particleDIC', particleDIC)
             call mpas_pool_get_array(particle % haloDataPool, 'particleALK', particleALK)
+            call mpas_pool_get_array(particle % haloDataPool, 'particlePO4', particlePO4)
+            call mpas_pool_get_array(particle % haloDataPool, 'particleNO3', particleNO3)
+            call mpas_pool_get_array(particle % haloDataPool, 'particleSiO3', particleSiO3)
+            call mpas_pool_get_array(particle % haloDataPool, 'particleNH4', particleNH4)
+            call mpas_pool_get_array(particle % haloDataPool, 'particleFe', particleFe)
+            call mpas_pool_get_array(particle % haloDataPool, 'particleO2', particleO2)
           end if 
 
 
@@ -2117,6 +2327,132 @@ contains
                 end if
                 call mpas_log_write('done testing output for ALK')
               end if
+
+               if (config_AM_lagrPartTrack_sample_PO4) then
+                 call mpas_log_write('testing output for PO4')
+                 if (config_AM_lagrPartTrack_sample_horizontal_interp) then
+                   call interp_scalars(particlePO4, ecosysTracers(index_PO4,:,:), &
+                     verticesOnCell(:,iCell), nCellVerticesArray(iCell), &
+                     particlePosition(1),particlePosition(2),particlePosition(3), &
+                     xVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     yVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     zVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     xCell, yCell, zCell, &
+                     meshPool, &
+                     cellsOnVertex, &
+                     verticalTreatment, maxLevelCell, iCell, buoyancyParticle, buoyancyTimeInterp, &
+                     zMid, indexLevel)
+                 else
+                   call interp_cell_scalars(iLevel, maxLevelCell(iCell), -zLevelParticle, -zMid(:,iCell), &
+                     ecosysTracers(index_PO4,:,iCell), particlePO4)
+                 end if
+                 call mpas_log_write('done testing output for PO4')
+               end if
+             
+               if (config_AM_lagrPartTrack_sample_NO3) then
+                 call mpas_log_write('testing output for NO3')
+                 if (config_AM_lagrPartTrack_sample_horizontal_interp) then
+                   call interp_scalars(particleNO3, ecosysTracers(index_NO3,:,:), &
+                     verticesOnCell(:,iCell), nCellVerticesArray(iCell), &
+                     particlePosition(1),particlePosition(2),particlePosition(3), &
+                     xVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     yVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     zVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     xCell, yCell, zCell, &
+                     meshPool, &
+                     cellsOnVertex, &
+                     verticalTreatment, maxLevelCell, iCell, buoyancyParticle, buoyancyTimeInterp, &
+                     zMid, indexLevel)
+                 else
+                   call interp_cell_scalars(iLevel, maxLevelCell(iCell), -zLevelParticle, -zMid(:,iCell), &
+                     ecosysTracers(index_NO3,:,iCell), particleNO3)
+                 end if
+                 call mpas_log_write('done testing output for NO3')
+               end if
+
+               if (config_AM_lagrPartTrack_sample_SiO3) then
+                 call mpas_log_write('testing output for SiO3')
+                 if (config_AM_lagrPartTrack_sample_horizontal_interp) then
+                   call interp_scalars(particleSiO3, ecosysTracers(index_SiO3,:,:), &
+                     verticesOnCell(:,iCell), nCellVerticesArray(iCell), &
+                     particlePosition(1),particlePosition(2),particlePosition(3), &
+                     xVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     yVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     zVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     xCell, yCell, zCell, &
+                     meshPool, &
+                     cellsOnVertex, &
+                     verticalTreatment, maxLevelCell, iCell, buoyancyParticle, buoyancyTimeInterp, &
+                     zMid, indexLevel)
+                 else
+                   call interp_cell_scalars(iLevel, maxLevelCell(iCell), -zLevelParticle, -zMid(:,iCell), &
+                     ecosysTracers(index_SiO3,:,iCell), particleSiO3)
+                 end if
+                 call mpas_log_write('done testing output for SiO3')
+               end if
+
+               if (config_AM_lagrPartTrack_sample_NH4) then
+                 call mpas_log_write('testing output for NH4')
+                 if (config_AM_lagrPartTrack_sample_horizontal_interp) then
+                   call interp_scalars(particleNH4, ecosysTracers(index_NH4,:,:), &
+                     verticesOnCell(:,iCell), nCellVerticesArray(iCell), &
+                     particlePosition(1),particlePosition(2),particlePosition(3), &
+                     xVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     yVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     zVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     xCell, yCell, zCell, &
+                     meshPool, &
+                     cellsOnVertex, &
+                     verticalTreatment, maxLevelCell, iCell, buoyancyParticle, buoyancyTimeInterp, &
+                     zMid, indexLevel)
+                 else
+                   call interp_cell_scalars(iLevel, maxLevelCell(iCell), -zLevelParticle, -zMid(:,iCell), &
+                     ecosysTracers(index_NH4,:,iCell), particleNH4)
+                 end if
+                 call mpas_log_write('done testing output for NH4')
+               end if
+
+               if (config_AM_lagrPartTrack_sample_Fe) then
+                 call mpas_log_write('testing output for Fe')
+                 if (config_AM_lagrPartTrack_sample_horizontal_interp) then
+                   call interp_scalars(particleFe, ecosysTracers(index_Fe,:,:), &
+                     verticesOnCell(:,iCell), nCellVerticesArray(iCell), &
+                     particlePosition(1),particlePosition(2),particlePosition(3), &
+                     xVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     yVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     zVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     xCell, yCell, zCell, &
+                     meshPool, &
+                     cellsOnVertex, &
+                     verticalTreatment, maxLevelCell, iCell, buoyancyParticle, buoyancyTimeInterp, &
+                     zMid, indexLevel)
+                 else
+                   call interp_cell_scalars(iLevel, maxLevelCell(iCell), -zLevelParticle, -zMid(:,iCell), &
+                     ecosysTracers(index_Fe,:,iCell), particleFe)
+                 end if
+                 call mpas_log_write('done testing output for Fe')
+               end if
+
+               if (config_AM_lagrPartTrack_sample_O2) then
+                 call mpas_log_write('testing output for O2')
+                 if (config_AM_lagrPartTrack_sample_horizontal_interp) then
+                   call interp_scalars(particleO2, ecosysTracers(index_O2,:,:), &
+                     verticesOnCell(:,iCell), nCellVerticesArray(iCell), &
+                     particlePosition(1),particlePosition(2),particlePosition(3), &
+                     xVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     yVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     zVertex(verticesOnCell(1:nCellVerticesArray(iCell),iCell)), &
+                     xCell, yCell, zCell, &
+                     meshPool, &
+                     cellsOnVertex, &
+                     verticalTreatment, maxLevelCell, iCell, buoyancyParticle, buoyancyTimeInterp, &
+                     zMid, indexLevel)
+                 else
+                   call interp_cell_scalars(iLevel, maxLevelCell(iCell), -zLevelParticle, -zMid(:,iCell), &
+                     ecosysTracers(index_O2,:,iCell), particleO2)
+                 end if
+                 call mpas_log_write('done testing output for O2')
+               end if
             end if
           end if
 

--- a/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
@@ -2043,7 +2043,7 @@ contains
       real (kind=RKIND), pointer :: particleDIC
       logical, pointer :: config_AM_lagrPartTrack_sample_ALK
       real (kind=RKIND), pointer :: particleALK
-      logical, pointer :: config_AM_lagrPartTrack_sample_PO$
+      logical, pointer :: config_AM_lagrPartTrack_sample_PO4
       real (kind=RKIND), pointer :: particlePO4
       logical, pointer :: config_AM_lagrPartTrack_sample_NO3
       real (kind=RKIND), pointer :: particleNO3

--- a/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
@@ -539,8 +539,8 @@ contains
           call mpas_pool_get_array(particle % haloDataPool, 'particleSalinity', particleSalinity)
 
           if (config_use_ecosysTracers) then
-            call mpas_pool_get_array(particle % haloDataPool, 'DIC', particleDIC)
-            call mpas_pool_get_array(particle % haloDataPool, 'ALK', particleALK)
+            call mpas_pool_get_array(particle % haloDataPool, 'particleDIC', particleDIC)
+            call mpas_pool_get_array(particle % haloDataPool, 'particleALK', particleALK)
           end if
 
 !          call mpas_pool_get_array(particle % haloDataPool, 'lonVel', lonVel)
@@ -1966,14 +1966,9 @@ contains
           call mpas_pool_get_array(particle % haloDataPool, 'particleTemperature', particleTemperature)
           call mpas_pool_get_array(particle % haloDataPool, 'particleSalinity', particleSalinity)
           if (config_use_ecosysTracers) then
-            call mpas_pool_get_array(particle % haloDataPool, 'DIC', particleDIC)
-            call mpas_pool_get_array(particle % haloDataPool, 'ALK', particleALK)
+            call mpas_pool_get_array(particle % haloDataPool, 'particleDIC', particleDIC)
+            call mpas_pool_get_array(particle % haloDataPool, 'particleALK', particleALK)
           end if 
-
-          if (config_use_ecosysTracers) then
-            call mpas_pool_get_array(particle % haloDataPool, 'DIC', particleDIC)
-            call mpas_pool_get_array(particle % haloDataPool, 'ALK', particleALK)
-          end if
 
 
 !          call mpas_pool_get_array(particle % haloDataPool, 'lonVel', lonVel)


### PR DESCRIPTION
@pwolfram, c5320aa69de3cb60589ce08e4a5791e8479196dd fixes the segfault issue we saw in https://github.com/pwolfram/MPAS-Model/pull/21. Feel free to cherry pick to that branch, if that's the appropriate path forward for something like this.

Simulation runs just fine on IC with DIC/ALK sensors following c5320aa69de3cb60589ce08e4a5791e8479196dd:
> /lustre/scratch3/turquoise/rileybrady/ACME/cases/GMPAS-OECO-ODMS-IAF.T62_oEC60to30v3.grizzly.9600o.128i.5ParticleLayers.Ton.Son.DICon.ALKon/run

I figured I would add a few commits here to follow up https://github.com/pwolfram/MPAS-Model/pull/21 with capability for the remaining passive tracers (e.g. NO3, PO4). Let me know if this sounds right.

Following this, I can run some timing tests for our 30to10 production run. 